### PR TITLE
Additional attributes for centralized ventilation

### DIFF
--- a/custom_components/blauberg_s21/climate.py
+++ b/custom_components/blauberg_s21/climate.py
@@ -213,9 +213,9 @@ class BlS21ClimateEntity(ClimateEntity):
             "timer_countdown": self._client.device.timer_countdown,
 
             # TODO: test different modes and their mapping
-            # TODO: overwrite manual fan_mode whenever schedule mode is active
             "is_schedule_mode": self._client.device.is_schedule_mode,
-            "current_schedule_mode_speed": self._client.device.current_schedule_mode_speed,
+            "fan_level_schedule_mode": self._client.device.fan_level_schedule_mode,
+            "fan_level_manual_mode": self._client.device.fan_level_manual_mode,
         }
     """ EO MaNi additions - additional attributes """
 

--- a/custom_components/blauberg_s21/climate.py
+++ b/custom_components/blauberg_s21/climate.py
@@ -161,8 +161,11 @@ class BlS21ClimateEntity(ClimateEntity):
 
     @property
     def supported_features(self) -> ClimateEntityFeature:
-        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
-
+        """ MaNi additions - additional attributes """
+        """ return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE """
+        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
+        """ EO MaNi additions - additional attributes """
+    
     @property
     def device_info(self) -> DeviceInfo | None:
         """Return information used by Home Assistant to register the device."""
@@ -188,6 +191,38 @@ class BlS21ClimateEntity(ClimateEntity):
             model=model,
             sw_version=sw_version,
         )
+
+    """ MaNi additions - additional attributes """
+    @property
+    def current_intake_temperature(self) -> Optional[str]:
+        if self._client.device:
+            return self._client.device.current_intake_temperature
+
+    @property
+    def current_temperature_fresh_air(self) -> Optional[str]:
+        if self._client.device:
+            return self._client.device.current_temperature_fresh_air
+
+    @property
+    def current_temperature_consumed_air(self) -> Optional[str]:
+        if self._client.device:
+            return self._client.device.current_temperature_consumed_air
+
+    @property
+    def filter_countdown(self) -> Optional[str]:
+        if self._client.device:
+            return self._client.device.filter_countdown
+
+    @property
+    def pressure_air_incoming(self) -> Optional[str]:
+        if self._client.device:
+            return self._client.device.pressure_air_incoming
+
+    @property
+    def pressure_air_outgoing(self) -> Optional[str]:
+        if self._client.device:
+            return self._client.device.pressure_air_outgoing
+    """ EO MaNi additions - additional attributes """
 
     @property
     def icon(self) -> str | None:

--- a/custom_components/blauberg_s21/climate.py
+++ b/custom_components/blauberg_s21/climate.py
@@ -199,7 +199,7 @@ class BlS21ClimateEntity(ClimateEntity):
         if not self._client.device:
             return {}
         return {
-            "current_intake_temperature_in": self._client.device.current_intake_temperature_in,
+            "current_intake_temperature_in": self._client.device.current_intake_temperature,
             "current_intake_temperature_out": self._client.device.current_intake_temperature_out,
             "current_outlet_temperature_in": self._client.device.current_outlet_temperature_in,
             "current_outlet_temperature_out": self._client.device.current_outlet_temperature_out,
@@ -210,10 +210,7 @@ class BlS21ClimateEntity(ClimateEntity):
             "pressure_air_outgoing": self._client.device.pressure_air_outgoing,
             "is_boosting": self._client.device.is_boosting,
             "is_timer": self._client.device.is_timer,
-
-            # TODO: combine into 1 attribute - hrs:min:00
-            "timer_min": self._client.device.timer_min,
-            "timer_hrs": self._client.device.timer_hrs,
+            "timer_countdown": self._client.device.timer_countdown,
 
             # TODO: test different modes and their mapping
             # TODO: overwrite manual fan_mode whenever schedule mode is active

--- a/custom_components/blauberg_s21/climate.py
+++ b/custom_components/blauberg_s21/climate.py
@@ -194,34 +194,32 @@ class BlS21ClimateEntity(ClimateEntity):
 
     """ MaNi additions - additional attributes """
     @property
-    def current_intake_temperature(self) -> Optional[str]:
-        if self._client.device:
-            return self._client.device.current_intake_temperature
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes."""
+        if not self._client.device:
+            return {}
+        return {
+            "current_intake_temperature_in": self._client.device.current_intake_temperature_in,
+            "current_intake_temperature_out": self._client.device.current_intake_temperature_out,
+            "current_outlet_temperature_in": self._client.device.current_outlet_temperature_in,
+            "current_outlet_temperature_out": self._client.device.current_outlet_temperature_out,
+            "alarm_state": self._client.device.alarm_state,
+            "filter_state": self._client.device.filter_state,
+            "filter_countdown": self._client.device.filter_countdown,
+            "pressure_air_incoming": self._client.device.pressure_air_incoming,
+            "pressure_air_outgoing": self._client.device.pressure_air_outgoing,
+            "is_boosting": self._client.device.is_boosting,
+            "is_timer": self._client.device.is_timer,
 
-    @property
-    def current_temperature_fresh_air(self) -> Optional[str]:
-        if self._client.device:
-            return self._client.device.current_temperature_fresh_air
+            # TODO: combine into 1 attribute - hrs:min:00
+            "timer_min": self._client.device.timer_min,
+            "timer_hrs": self._client.device.timer_hrs,
 
-    @property
-    def current_temperature_consumed_air(self) -> Optional[str]:
-        if self._client.device:
-            return self._client.device.current_temperature_consumed_air
-
-    @property
-    def filter_countdown(self) -> Optional[str]:
-        if self._client.device:
-            return self._client.device.filter_countdown
-
-    @property
-    def pressure_air_incoming(self) -> Optional[str]:
-        if self._client.device:
-            return self._client.device.pressure_air_incoming
-
-    @property
-    def pressure_air_outgoing(self) -> Optional[str]:
-        if self._client.device:
-            return self._client.device.pressure_air_outgoing
+            # TODO: test different modes and their mapping
+            # TODO: overwrite manual fan_mode whenever schedule mode is active
+            "is_schedule_mode": self._client.device.is_schedule_mode,
+            "current_schedule_mode_speed": self._client.device.current_schedule_mode_speed,
+        }
     """ EO MaNi additions - additional attributes """
 
     @property

--- a/custom_components/blauberg_s21/climate.py
+++ b/custom_components/blauberg_s21/climate.py
@@ -10,6 +10,9 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.components.climate.const import (
+    # MaNi additions - additional attributes
+    FAN_OFF,
+    # EO MaNi additions - additional attributes
     FAN_HIGH,
     FAN_LOW,
     FAN_MEDIUM,
@@ -43,7 +46,10 @@ S21_TO_HA_HVACACTION = {
     BlS21HVACAction.OFF: HVACAction.OFF,
 }
 
-S21_TO_HA_FAN_MODE = {1: FAN_LOW, 2: FAN_MEDIUM, 3: FAN_HIGH, 255: "custom"}
+""" MaNi additions - additional attributes """
+# S21_TO_HA_FAN_MODE = {1: FAN_LOW, 2: FAN_MEDIUM, 3: FAN_HIGH, 255: "custom"}
+S21_TO_HA_FAN_MODE = {0: FAN_OFF, 1: FAN_LOW, 2: FAN_MEDIUM, 3: FAN_HIGH, 255: "custom"}
+""" EO MaNi additions - additional attributes """
 
 
 async def async_setup_entry(
@@ -211,11 +217,9 @@ class BlS21ClimateEntity(ClimateEntity):
             "is_boosting": self._client.device.is_boosting,
             "is_timer": self._client.device.is_timer,
             "timer_countdown": self._client.device.timer_countdown,
-
-            # TODO: test different modes and their mapping
             "is_schedule_mode": self._client.device.is_schedule_mode,
-            "fan_level_schedule_mode": self._client.device.fan_level_schedule_mode,
-            "fan_level_manual_mode": self._client.device.fan_level_manual_mode,
+            "fan_level_schedule_mode": S21_TO_HA_FAN_MODE.get(self._client.device.fan_level_schedule_mode, str(self._client.device.fan_level_schedule_mode) ),
+            "fan_level_manual_mode": S21_TO_HA_FAN_MODE.get(self._client.device.fan_level_manual_mode, str(self._client.device.fan_level_manual_mode) ),
         }
     """ EO MaNi additions - additional attributes """
 

--- a/custom_components/blauberg_s21/const.py
+++ b/custom_components/blauberg_s21/const.py
@@ -1,3 +1,3 @@
-"""Constants for the Blauberg S21 integration."""
+"""Constants for the Blauberg S21 integration with extented attributes."""
 
-DOMAIN = "blauberg_s21"
+DOMAIN = "blauberg_s21_ext"

--- a/custom_components/blauberg_s21/manifest.json
+++ b/custom_components/blauberg_s21/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@jvitkauskas"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/jvitkauskas/homeassistant_blauberg_s21",
+  "documentation": "https://github.com/marni-xyz/homeassistant_blauberg_s21",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/jvitkauskas/homeassistant_blauberg_s21/issues",
+  "issue_tracker": "https://github.com/marni-xyz/homeassistant_blauberg_s21/issues",
   "requirements": ["git+https://github.com/marni-xyz/pybls21ext.git@additions"],
   "version": "0.4.1"
 }

--- a/custom_components/blauberg_s21/manifest.json
+++ b/custom_components/blauberg_s21/manifest.json
@@ -1,13 +1,13 @@
 {
-  "domain": "blauberg_s21",
-  "name": "Blauberg S21",
-  "codeowners": ["@jvitkauskas"],
+  "domain": "blauberg_s21_ext",
+  "name": "Blauberg S21 Extended",
+  "codeowners": ["@jvitkauskas", "@marni-xyz"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/jvitkauskas/homeassistant_blauberg_s21",
+  "documentation": "https://github.com/marni-xyz/homeassistant_blauberg_s21",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/jvitkauskas/homeassistant_blauberg_s21/issues",
-  "requirements": ["pybls21ext@git+https://github.com/marni-xyz/pybls21ext.git@additions"],
+  "issue_tracker": "https://github.com/marni-xyz/homeassistant_blauberg_s21/issues",
+  "requirements": ["pybls21@git+https://github.com/marni-xyz/pybls21.git@additions"],
   "version": "0.4.1"
 }

--- a/custom_components/blauberg_s21/manifest.json
+++ b/custom_components/blauberg_s21/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jvitkauskas/homeassistant_blauberg_s21/issues",
   "requirements": ["git+https://github.com/marni-xyz/pybls21ext.git@additions"],
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/custom_components/blauberg_s21/manifest.json
+++ b/custom_components/blauberg_s21/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jvitkauskas/homeassistant_blauberg_s21/issues",
-  "requirements": ["pybls21==4.2.2"],
+  "requirements": ["git+https://github.com/marni-xyz/pybls21ext.git@additions"],
   "version": "0.4.0"
 }

--- a/custom_components/blauberg_s21/manifest.json
+++ b/custom_components/blauberg_s21/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@jvitkauskas"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/marni-xyz/homeassistant_blauberg_s21",
+  "documentation": "https://github.com/jvitkauskas/homeassistant_blauberg_s21",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/marni-xyz/homeassistant_blauberg_s21/issues",
-  "requirements": ["git+https://github.com/marni-xyz/pybls21ext.git@additions"],
+  "issue_tracker": "https://github.com/jvitkauskas/homeassistant_blauberg_s21/issues",
+  "requirements": ["pybls21ext@git+https://github.com/marni-xyz/pybls21ext.git@additions"],
   "version": "0.4.1"
 }


### PR DESCRIPTION
New attributes:
- current_intake_temperature_out  # fresh air from ventilation into rooms
- current_outlet_temperature_in   # used air from rooms into ventilation
- current_outlet_temperature_out  # used air from ventilation to the outside 
- filter_countdown
- pressure_air_incoming
- pressure_air_outgoing
- timer + countdown of timer
- scheduler + fan level according to current scheduler timeframe
- bugfix: fan level in line with schedule mode (schedule overrides manual mode)